### PR TITLE
The url property should be used to get a download link from a FileField

### DIFF
--- a/html/forms.html
+++ b/html/forms.html
@@ -10,7 +10,7 @@
             <p><a href="{{ form.form.esign.template }}">Esign Here</a></p><br>
           {% endif %}
           <p style="padding-bottom: 10px;">
-            <a href="{{ form.form.form }}" class="mui-btn">Download Form</a>
+            <a href="{{ form.form.form.url }}" class="mui-btn">Download Form</a>
           </p>
         </div><br>
     {% endfor %}


### PR DESCRIPTION
I did a quick search through the code for other FileField usage in the templates and this is the only case I noticed where we were building the link without using `.url`